### PR TITLE
Fix trustedProxyHeaders

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -75,7 +75,7 @@ export class PirschNodeApiClient extends PirschCoreClient {
                     return PIRSCH_PROXY_HEADERS.includes(header);
                 })
                 .find(header => {
-                    typeof request.headers[header] === "string";
+                    return typeof request.headers[header] === "string";
                 });
 
             if (header) {


### PR DESCRIPTION
Without this return statement, trustedProxyHeaders are always ignored since this find check always implicitly returns undefined.